### PR TITLE
ChatButtonPayload.chatTitle is required

### DIFF
--- a/schema.yaml
+++ b/schema.yaml
@@ -2070,7 +2070,6 @@ components:
             chat_title:
               description: 'Title of chat to be created'
               readOnly: false
-              nullable: true
               type: string
               maxLength: 200
             chat_description:

--- a/schema.yaml
+++ b/schema.yaml
@@ -2093,6 +2093,8 @@ components:
               readOnly: false
               nullable: true
               type: integer
+          required:
+            - chat_title
     Intent:
       description: Intent of button
       type: string


### PR DESCRIPTION
When trying to send without chat title, getting an error: `{"code":"proto.payload","message":"Object has missing required property: ChatButtonPayload.chatTitle"}`